### PR TITLE
failover logic added to limitd client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 before_install: npm i -g npm@2
 node_js:
-  - "0.8"
-  - "0.10"
-  - "0.12"
-  - "iojs"
+  - "4"
+  - "5"
+  

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "protobufjs": "~4.0.0-b2",
     "randomstring": "~1.0.5",
     "reconnect-net": "0.0.0",
+    "tcp-client-failover": "^1.0.1",
     "through2": "~2.0.0"
   },
   "devDependencies": {

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -39,7 +39,6 @@ describe('limitd client', function () {
 
       client[method]('ip', '191.12.23.32', 1);
     });
-
   });
 
 

--- a/test/failover.tests.js
+++ b/test/failover.tests.js
@@ -1,0 +1,113 @@
+var _         = require('lodash');
+var assert    = require('assert');
+var protocol  = require('../lib/protocol');
+var LimitdClient  = require('../');
+var MockServer    = require('./MockServer');
+
+var PORT = 9231;
+
+describe('limitd client failover', function() {
+
+  var client;
+  var servers = [];
+
+  // start three services
+  beforeEach((done) => {
+    
+    function createClient() {
+      var config = {
+        hosts: _.map(servers, (server, index) => {
+          return 'limitd://localhost:' + (PORT + index);
+        }),
+        timeout: 3000
+      };
+
+      client = new LimitdClient(config); 
+      client.once('connect', done);
+    }
+
+    var count = 3;
+    servers = _.map(_.range(3), (i) => {
+      var port = PORT + i;
+      var server = new MockServer({ port: port });
+      server.listen(function () {
+        if (++i === count) {
+          createClient();
+        }
+      });
+      servers.push(server);
+      return server;
+    });
+  });
+
+  // close all services
+  afterEach(() => {
+    servers.map((server) => {
+      server.close();
+    });
+  });
+
+  it('should connect to first service', function(done) {
+
+    servers[0].once('request', function (request) {
+      assert.equal(typeof request.id, 'string');
+      assert.equal(request.method, protocol.Request.Method.TAKE);
+      assert.equal(request.type, 'ip');
+      assert.equal(request.count, 1);
+      assert.equal(request.all, false);
+      done();
+    });
+
+    // invoke service
+    client.take('ip', '191.12.23.32', 1);
+  });
+
+  it('should connect to second service when first is down', function(done) {
+
+    servers[1].once('request', function (request) {
+      assert.equal(typeof request.id, 'string');
+      assert.equal(request.method, protocol.Request.Method.TAKE);
+      assert.equal(request.type, 'ip');
+      assert.equal(request.count, 1);
+      assert.equal(request.all, false);
+      done();
+    });
+
+    // stop first service
+    servers[0].close(function (err) {
+      assert.ok(!err);
+      // invoke service
+      setTimeout(client.take.bind(client), 1000, 'ip', '191.12.23.32', 1);
+    });
+  });
+
+  it('should connect to first service after it is back', function(done) {
+
+    servers[0].once('request', function (request) {
+      assert.equal(typeof request.id, 'string');
+      assert.equal(request.method, protocol.Request.Method.TAKE);
+      assert.equal(request.type, 'ip');
+      assert.equal(request.count, 1);
+      assert.equal(request.all, false);
+      done();
+    });
+
+    // stop first service
+    servers[0].close(function (err) {
+      assert.ok(!err);
+
+      // wait a second
+      setTimeout(function() {
+
+        // restart first service
+        servers[0].listen(function (err) {
+          assert.ok(!err);
+
+          // invoke service
+          setTimeout(client.take.bind(client), 1000, 'ip', '191.12.23.32', 1);
+        });
+      }, 1000);
+    });
+  });
+
+});


### PR DESCRIPTION
Configuration accepts an array of services. For instance:
```
var config = [ ''limitd://localhost:9001", ''limitd://localhost:9002", ''limitd://localhost:9003" ];
var client = new LimitdClient(config);
```
The client will connect to the first service, when first service is down, the client will switch to the second one. After first service is up again, the client will switch to it.
