### PR TITLE
tcp-client-failover dependency updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "protobufjs": "~4.0.0-b2",
     "randomstring": "~1.0.5",
     "reconnect-net": "0.0.0",
-    "tcp-client-failover": "^1.0.1",
+    "tcp-client-failover": "^1.0.2",
     "through2": "~2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
A dependency was updated in order to fix a bug.
The dependency was raising up false `disconnected` events.