### PR TITLE
Fix uncaught when calling pool methods

### DIFF
--- a/pool.js
+++ b/pool.js
@@ -34,14 +34,19 @@ function LimitdPool (options, done) {
         clients.push(client);
         done();
       });
-    }, done);
+    }, function() {
+      pool.emit('ready');
+      done();
+    });
 }
 
 util.inherits(LimitdPool, EventEmitter);
 
 LimitdPool.prototype._getClient = function () {
   if (this._clients.length === 0) {
-    return;
+    // if we have no suitable client, return an empty
+    // one so call can still go through
+    return new LimitdClient();
   }
 
   this._current_client++;
@@ -55,9 +60,10 @@ LimitdPool.prototype._getClient = function () {
 
 Object.keys(LimitdClient.prototype).forEach(function (method) {
   LimitdPool.prototype[method] = function () {
-   var client = this._getClient();
-   client[method].apply(client, arguments);
+    var client = this._getClient();
+    client[method].apply(client, arguments);
   };
 });
 
 module.exports = LimitdPool;
+

--- a/test/pool.tests.js
+++ b/test/pool.tests.js
@@ -1,0 +1,54 @@
+var _         = require('lodash');
+var assert    = require('assert');
+var protocol  = require('../lib/protocol');
+var LimitdClient  = require('../');
+var MockServer    = require('./MockServer');
+
+var PORT = 9231;
+
+describe('limitd client pool', function() {
+
+  var server = [];
+
+  // start three services
+  beforeEach((done) => {
+    server = new MockServer({ port: PORT });
+    server.listen(function () {
+      done();
+    });
+  });
+
+  afterEach(() => {
+    server.close();
+  });
+
+  it('should connect to server', function(done) {
+
+    server.once('request', function (request) {
+      assert.equal(typeof request.id, 'string');
+      assert.equal(request.method, protocol.Request.Method.TAKE);
+      assert.equal(request.type, 'ip');
+      assert.equal(request.count, 1);
+      assert.equal(request.all, false);
+      done();
+    });
+
+    // invoke service
+    var pool = new LimitdClient.Pool('limitd://localhost:' + PORT);
+    pool.on('ready', function() {
+      pool.take('ip', '191.12.23.32', 1);
+    });
+  });
+
+  it('should return error on callback if no connection is available', function(done) {
+    var pool = new LimitdClient.Pool('limitd://localhost:4321');
+    // it will never emit ready because it will try to reconnect the clients
+    // indefinitely
+    setTimeout(function() {
+      pool.take('ip', '191.12.23.32', 1, function(err) {
+        assert.equal(err.message, 'The socket is closed.');
+        done();
+      });
+    }, 1000);
+  });
+});


### PR DESCRIPTION
Changes:
- Return a closed limitd client (instead of returning `undefined`) if no client is available to run a command (e.g. `TAKE`, `PING`, etc)
- Emit `ready` once all clients are connected

Important: if we have only one client in the options passed through the pool, it will try reconnecting indefinitely if the server until the server is back online (without emitting `ready` until then).
