### PR TITLE
retry put and status requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lodash": "~3.7.0",
     "murmurhash3js": "^3.0.1",
     "reconnect-net": "0.0.0",
+    "retry": "^0.10.1",
     "tcp-client-failover": "^1.0.2"
   },
   "devDependencies": {

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -14,8 +14,19 @@ describe('limitd client (standard)', function () {
   });
 
   before(function (done) {
-    client = new LimitdClient({ protocol_version: 2 });
+    client = new LimitdClient({
+      protocol_version: 2,
+      retry: {
+        minTimeout: 1,
+        maxTimeout: 5,
+      },
+      timeout: 10
+    });
     client.once('connect', done);
+  });
+
+  beforeEach(() => {
+    client.resetCircuitBreaker();
   });
 
   after(function (done) {

--- a/test/retry.tests.js
+++ b/test/retry.tests.js
@@ -1,0 +1,53 @@
+const MockServer = require('./MockServer');
+const LimitdClient = require('../');
+const port = 54325;
+const assert = require('chai').assert;
+
+describe('retry errors', function () {
+  const server = new MockServer({ port });
+  var client;
+
+  before(done => server.listen(done));
+
+  beforeEach(done => {
+    server.removeAllListeners('request');
+    client = new LimitdClient({
+      hosts: [`limitd://localhost:${port}`],
+    }, done);
+  });
+
+  it('should not retry UNKNOWN_BUCKET_TYPE errors', function (done) {
+    var times = 0;
+
+    server.on('request', function handler(request, reply) {
+      times++;
+      const response = {
+        request_id: request.id,
+        'error': {
+          type: 'UNKNOWN_BUCKET_TYPE'
+        }
+      };
+      reply(response);
+    });
+
+
+    client.take('ip', '1232.312.error', 1, function (err) {
+      assert.equal(times, 1);
+      assert.equal(err.message, 'Invalid bucket type');
+      done();
+    });
+  });
+
+
+  it('should retry on timeout', function(done) {
+    var times = 0;
+
+    server.on('request', () => times++);
+
+    client.take('ip', '1232.312.error', function (err) {
+      assert.equal(times, 4);
+      assert.match(err.message, /timeout/);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Changes:

-  circuit-breaker maxFailures from 5 to 30. The circuit should be open when we detect several failures and when we want to assume the backend will take longer to recover.
-  circuit-breaker default cooldown from 15s to min 5s and max 20s. The first attempt should happen sooner.
-  circuit-breaker timeout from 1s to 400ms. The reason is that when limitd is working requests take usually less than 5ms, we don't need to wait 1s.
-  retry put and status requests 3 times unless the circuit is open.