### PR TITLE
Fix .status issue when number of host in shard are increased

### DIFF
--- a/shard_client.js
+++ b/shard_client.js
@@ -121,6 +121,8 @@ ShardClient.prototype.status = function(type, prefix, callback) {
       if (err) {
         return callback(null, { error: err });
       }
+
+      response.items = response.items.filter(i => this.getDestinationClient(type, i.instance) === client);
       callback(null, response);
     });
   }, (err, responses) => {


### PR DESCRIPTION
Lets asume a shard with 2 hosts (A, B), and the following routing for Keys:
'instance1' -> A
'instance2' -> B

if we add a new host to the shard, the routing might endup being
'instance1' -> A
'instance2' -> C

However, B will contain an stale record for 'instance2' from the old
configuration. Getting .status() crawls all the nodes in the shard,
meaning that we need to discard the 'instance2' from node B since it is
stale, and use the one in node C instead.