### PR TITLE
Add missing error handler

### DIFF
--- a/client.js
+++ b/client.js
@@ -184,6 +184,7 @@ LimitdClient.prototype._connectUsingReconnect = function (done) {
                   this._onNewStream(stream);
                   this.socket.once('disconnect', (err) => {
                     this.emit('disconnect', err);
+                    socket.emit('error', err);
                   });
                   self.emit('connect');
                 }).on('close', (has_error) => {
@@ -196,6 +197,7 @@ LimitdClient.prototype._connectUsingReconnect = function (done) {
                     return;
                   }
                   this.emit('error', err);
+                  socket.emit('error', err);
                 }).on('reconnect', (n, delay) => {
                   this.emit('reconnect', n, delay);
                 }).connect(port, host);

--- a/client.js
+++ b/client.js
@@ -228,6 +228,9 @@ LimitdClient.prototype._onNewStream = function (stream) {
 
   stream
   .pipe(lps.decode())
+  .on('error', (err) => {
+    this.emit('error', err);
+  })
   .pipe(Transform({
     objectMode: true,
     transform(chunk, enc, callback) {


### PR DESCRIPTION
The `pipe` on client.js was missing an error handler.

The repl output below shows that an uncaught error might be thrown in that case:

```js
const Stream = require('stream')
undefined
> const s1 = new Stream()
undefined
> const s2 = new Stream()
undefined
> s1.pipe(s2).on('error', (err) => console.log('Handled error!'))
...
> s2.emit('error', new Error('my error'))
Handled error!
true
> s1.emit('error', new Error('my error'))
Error: my error
    at repl:1:18
    at REPLServer.defaultEval (repl.js:272:27)
    at bound (domain.js:287:14)
    at REPLServer.runBound [as eval] (domain.js:300:12)
    at REPLServer.<anonymous> (repl.js:441:12)
    at emitOne (events.js:82:20)
    at REPLServer.emit (events.js:169:7)
    at REPLServer.Interface._onLine (readline.js:203:10)
    at REPLServer.Interface._line (readline.js:542:8)
    at REPLServer.Interface._ttyWrite (readline.js:819:14)
> false
```