### PR TITLE
Added error handler to stream to avoid unhandled exceptions

### DIFF
--- a/test/MockDecoder.js
+++ b/test/MockDecoder.js
@@ -1,0 +1,14 @@
+var util = require('util')
+var stream = require('readable-stream')
+
+var MockDecoder = function () {
+  stream.Transform.call(this)
+}
+
+util.inherits(MockDecoder, stream.Transform)
+
+MockDecoder.prototype._transform = function (data, enc, cb) {
+  cb()
+}
+
+module.exports = MockDecoder;

--- a/test/epipe_error.decoder.tests.js
+++ b/test/epipe_error.decoder.tests.js
@@ -1,9 +1,20 @@
 const MockServer = require('./MockServer');
-const LimitdClient = require('../');
+const MockDecoder = require('./MockDecoder');
+const $require = require('proxyquire').noPreserveCache();
+
+const mockDecoder = new MockDecoder();
+const LimitdClient = $require('../Client', {
+  'length-prefixed-stream': {
+    decode: () => {
+      return mockDecoder;
+    }
+  }
+});
+
 const port = 54115;
 const assert = require('chai').assert;
 
-describe('epipe errors', function () {
+describe('error in length prefix stream decode', function () {
   const server = new MockServer({ port });
   var client;
 
@@ -27,7 +38,10 @@ describe('epipe errors', function () {
       assert.equal(err.message, 'fire');
       done();
     });
-    client.stream.emit('close');
-    client.stream.emit('error', new Error('fire'));
+
+    mockDecoder.emit('close');
+    mockDecoder.emit('error', new Error('fire'));
   });
 });
+
+


### PR DESCRIPTION
It seems that pipes do not forward errors. We need to handle errors in each step (I based the fix on this - http://grokbase.com/t/gg/nodejs/12bwd4zm4x/should-stream-pipe-forward-errors )